### PR TITLE
Add Docker support with multi-stage build

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,39 @@
+# Build stage
+FROM ubuntu:22.04 AS builder
+
+# Install build dependencies
+RUN apt-get update && apt-get install -y \
+    build-essential \
+    cmake \
+    pkg-config \
+    git \
+    libsrt-dev \
+    && rm -rf /var/lib/apt/lists/*
+
+# Set working directory
+WORKDIR /app
+
+# Copy source files
+COPY . .
+
+# Build the project
+RUN mkdir build && cd build \
+    && cmake .. \
+    && make -j$(nproc)
+
+# Runtime stage
+FROM ubuntu:22.04
+
+# Install runtime dependencies
+RUN apt-get update && apt-get install -y \
+    libsrt-dev \
+    && rm -rf /var/lib/apt/lists/*
+
+# Copy built executables and configs
+COPY --from=builder /app/build/visca_srt_server /usr/local/bin/
+COPY --from=builder /app/build/visca_srt_client /usr/local/bin/
+COPY --from=builder /app/build/srt_example /usr/local/bin/
+COPY config/ /etc/visca_srt/
+
+# Set default command (can be overridden)
+CMD ["visca_srt_server"]

--- a/README.md
+++ b/README.md
@@ -309,6 +309,25 @@ This repository contains example implementations of different SRT (Secure Reliab
 
 ## Installation
 
+### Using Docker
+You can build and run the project using Docker:
+
+```bash
+# Build the Docker image
+docker build -t visca-srt .
+
+# Run the server (using host network for SRT connectivity)
+docker run --network host visca-srt
+
+# Run the client (override default command)
+docker run --network host visca-srt visca_srt_client
+
+# Run with custom configuration
+docker run -v /path/to/config:/etc/visca_srt visca-srt
+```
+
+The Docker image uses a multi-stage build to minimize size and includes all necessary dependencies. The server configuration can be customized by mounting a local config directory to `/etc/visca_srt` in the container.
+
 ### Using Homebrew
 The easiest way to install on macOS is using Homebrew:
 


### PR DESCRIPTION
This PR adds Docker support to the project with:

- Multi-stage Dockerfile optimized for minimal image size
- Build stage with all development dependencies
- Runtime stage with only required libraries
- Updated README.md with Docker usage instructions
- Support for custom configuration via volume mounting
- Host network mode for proper SRT connectivity

The Dockerfile builds all components (server, client, and examples) and includes necessary runtime configurations.